### PR TITLE
add MQTT topics docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains protocol documentation.
 ### Edge to Core
 
 - `events/up/SENDER/#` (signed)
-  - [new_aggregate](events-mqtt-message-new_qname.yaml)
+  - [new_qname](events-mqtt-message-new_qname.yaml)
 
 - `status/up/SENDER/#` (signed)
   - TBD


### PR DESCRIPTION
We need to document all used MQTT topics, as well as what messages are sent on those.