### PR TITLE
Draft status messages for EDM & POP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 edge-observations.json
-events/new_aggregate.json
-events/new_qname.json
+events/*.json
+status/*.json
 package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 GENERATED=	events/new_qname.json \
 		events/new_aggregate.json \
+		status/status_edm.json \
+		status/status_pop.json \
 		edge-observations.json
 
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ This repository contains protocol documentation.
 ### Edge to Core
 
 - `events/up/SENDER/#` (signed)
-  - [new_qname](events-mqtt-message-new_qname.yaml)
+  - [new_qname](events/new_qname.yaml)
 
-- `status/up/SENDER/#` (signed)
-  - TBD
+- `status/edm/up/SENDER/#` (signed)
+  - [edm_status](status/status_edm.yaml)
+
+- `status/pop/up/SENDER/#` (signed)
+  - [pop_status](status/status_pop.yaml)
 
 ### Core to Edge
 
@@ -28,4 +31,4 @@ This repository contains protocol documentation.
 ### Core to Core
 
 - `aggregates` (unsigned)
-  - [new_aggregate](events-mqtt-message-new_aggregate.yaml)
+  - [new_aggregate](events/new_aggregate.yaml)

--- a/status/status_edm.yaml
+++ b/status/status_edm.yaml
@@ -6,6 +6,7 @@ type: object
 required:
   - type
   - version
+  - state
 additionalProperties: true
 properties:
   type:

--- a/status/status_edm.yaml
+++ b/status/status_edm.yaml
@@ -1,0 +1,20 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+
+$id: https://schema.dnstapir.se/v1/status/edm
+
+type: object
+required:
+  - type
+  - version
+additionalProperties: true
+properties:
+  type:
+    const: status_edm
+  version:
+    minimum: 0
+    type: integer
+  state:
+    type: string
+    enum:
+      - connected
+      - disconnected

--- a/status/status_pop.yaml
+++ b/status/status_pop.yaml
@@ -6,6 +6,7 @@ type: object
 required:
   - type
   - version
+  - state
 additionalProperties: true
 properties:
   type:

--- a/status/status_pop.yaml
+++ b/status/status_pop.yaml
@@ -1,0 +1,20 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+
+$id: https://schema.dnstapir.se/v1/status/pop
+
+type: object
+required:
+  - type
+  - version
+additionalProperties: true
+properties:
+  type:
+    const: status_pop
+  version:
+    minimum: 0
+    type: integer
+  state:
+    type: string
+    enum:
+      - connected
+      - disconnected


### PR DESCRIPTION
Closes #8 

Status placeholders for EDM & POP. "disconnected" state messages should be configured as "last will" in MQTT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new connection status message types for EDM and POP state reporting, including JSON schema definitions for `connected`/`disconnected`.
* **Documentation**
  * Updated MQTT topic documentation with signed status channels and revised event link references.
* **Chores**
  * Expanded the build generation list to include new status artifacts.
  * Updated ignore rules to omit generated status/event JSON files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->